### PR TITLE
Update Databricks Provider to support workspace_level tagging feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ This Terraform code is provided as a sample for reference and testing purposes o
 | <a name="input_ws_ld_availability_zones"></a> [ws\_ld\_availability\_zones](#input\_ws\_ld\_availability\_zones) | Availability zone for AppStream | `list(string)` | n/a | yes |
 | <a name="input_ws_ld_private_subnets_cidr"></a> [ws\_ld\_private\_subnets\_cidr](#input\_ws\_ld\_private\_subnets\_cidr) | CIDR for AppStream private subnets | `list(string)` | n/a | yes |
 | <a name="input_ws_ld_vpc_cidr_range"></a> [ws\_ld\_vpc\_cidr\_range](#input\_ws\_ld\_vpc\_cidr\_range) | CIDR range for AppStream VPC | `string` | n/a | yes |
-
+| <a name="workspace_level_tags"></a> [workspace_level_tags](#input\workspace_level_tags) | The custom tags key-value pairing that is attached to this workspace| `map(string)` | {"workspace_tag_sample" = "isolake"} | yes |
 
 -----------
 

--- a/tf/isolake.tf
+++ b/tf/isolake.tf
@@ -33,6 +33,7 @@ module "isolake" {
   availability_zones   = ["us-east-1a", "us-east-1b"]   // Availability zones for resource deployment
   sg_ingress_protocol  = ["tcp", "udp"]                 // Allowed protocols for within security group ingress
   sg_egress_protocol   = ["tcp", "udp"]                 // Allowed protocols for within security group egress
+  workspace_level_tags = { "workspace_tag_sample" = "isolake" }
 
   // Optional frontend lockdown through AWS AppStream and PrivateLink
   enable_front_end_lockdown  = false           // Flag to enable frontend lockdown

--- a/tf/modules/isolake/audit/audit_logs.tf
+++ b/tf/modules/isolake/audit/audit_logs.tf
@@ -3,7 +3,7 @@ resource "null_resource" "previous" {}
 resource "time_sleep" "wait_30_seconds" {
   depends_on      = [null_resource.previous]
   create_duration = "30s"
-} 
+}
 // Databricks Credential Configuration for Logs
 resource "databricks_mws_credentials" "log_writer" {
   account_id       = var.databricks_account_id

--- a/tf/modules/isolake/dbx.tf
+++ b/tf/modules/isolake/dbx.tf
@@ -19,6 +19,7 @@ module "databricks_mws_workspace" {
   workspace_storage_key       = aws_kms_key.workspace_storage.arn
   managed_storage_key_alias   = aws_kms_alias.managed_storage_key_alias.name
   workspace_storage_key_alias = aws_kms_alias.workspace_storage_key_alias.name
+  workspace_level_tags        = var.workspace_level_tags
 }
 
 // Create Unity Catalog if not provided

--- a/tf/modules/isolake/variables.tf
+++ b/tf/modules/isolake/variables.tf
@@ -165,3 +165,8 @@ variable "workspace_vpce_service" {
   description = "VPCE service for workspace"
   type        = string
 }
+
+variable "workspace_level_tags" {
+  description = "The custom tags key-value pairing that is attached to this workspace. "
+  type        = map(string)
+}

--- a/tf/modules/isolake/workspace/variables.tf
+++ b/tf/modules/isolake/workspace/variables.tf
@@ -53,3 +53,7 @@ variable "managed_storage_key_alias" {
 variable "workspace_storage_key_alias" {
   type = string
 }
+
+variable "workspace_level_tags" {
+  type = map(string)
+}

--- a/tf/modules/isolake/workspace/workspace.tf
+++ b/tf/modules/isolake/workspace/workspace.tf
@@ -96,5 +96,6 @@ resource "databricks_mws_workspaces" "this" {
   managed_services_customer_managed_key_id = databricks_mws_customer_managed_keys.managed_storage.customer_managed_key_id
   storage_customer_managed_key_id          = databricks_mws_customer_managed_keys.workspace_storage.customer_managed_key_id
   pricing_tier                             = "ENTERPRISE"
+  custom_tags                              = var.workspace_level_tags
   depends_on                               = [databricks_mws_networks.this]
 }

--- a/tf/provider.tf
+++ b/tf/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     databricks = {
       source  = "databricks/databricks"
-      version = "1.27.0"
+      version = "1.35.0"
     }
     aws = {
       source = "hashicorp/aws"

--- a/tf/variables.tf
+++ b/tf/variables.tf
@@ -35,3 +35,11 @@ variable "resource_prefix" {
   description = "Prefix for naming created resources"
   type        = string
 }
+
+variable "workspace_level_tags" {
+  description = "The custom tags key-value pairing that is attached to this workspace."
+  type        = map(string)
+  default = {
+    "workspace_tag_sample" = "isolake"
+  }
+}


### PR DESCRIPTION
- Updated the Terraform provider to [1.35.0](https://github.com/databricks/terraform-provider-databricks/blob/main/CHANGELOG.md) and enabled the [custom_tags](https://github.com/databricks/terraform-provider-databricks/blob/main/CHANGELOG.md) attribute to the `databricks_mws_workspaces` resource in the sample code.
- Updated the README file